### PR TITLE
Add tests that break hash by modifying keyptr.

### DIFF
--- a/t/06_keymod1.t
+++ b/t/06_keymod1.t
@@ -1,0 +1,29 @@
+use strict;
+use warnings;
+use Test::More;
+
+use Devel::Peek;
+use Cache::utLRU;
+
+my $cache = Cache::utLRU->new();
+
+# Prepare the key SV. Concatenation is to make sure the PV buffer is not marked
+# as copy-on-write, and assignment below modifies the buffer itself, instead of
+# changing the PV pointer.
+my $key = "foo"."bar";
+Dump($key);
+
+# Cache will store the PV pointer and length in the internal hash structure.
+$cache->add($key, "value");
+
+# Change the buffer. This will change the memory that internal key pointer is
+# pointing to. PV pointer should have the same address as before in this dump.
+$key = "baz";
+Dump($key);
+
+# On lookup, we can locate the bucket, but since the memory at the keyptr has changed,
+# we don't get the match.
+my $val = $cache->find("foobar");
+is $val, "value", "value found";
+
+done_testing;

--- a/t/07_keymod2.t
+++ b/t/07_keymod2.t
@@ -1,0 +1,29 @@
+use strict;
+use warnings;
+use Test::More;
+
+use Devel::Peek;
+use Cache::utLRU;
+
+my $cache = Cache::utLRU->new();
+
+# Prepare the key SV. Concatenation is to make sure that string is not marked
+# copy-on-write, and perl can grow the buffer when we modify it below.
+my $key = "foo" . "bar";
+Dump($key);
+
+# Cache will store the PV pointer and length in the internal hash structure.
+$cache->add($key, "value");
+
+# Append to the string. This causes buffer to be re-allocated, leaving the key
+# pointer in the hash dangling.
+$key .= "straw that broke the camel's back";
+Dump($key);
+
+# On lookup we locate the bucket, but key check in cache_find() will read from
+# the freed memory when checking the key. This does not cause a crash on my
+# machine, but is caught by valgrind.
+my $val = $cache->find("foobar");
+is $val, "value", "value was found";
+
+done_testing;

--- a/t/08_keymod3.t
+++ b/t/08_keymod3.t
@@ -1,0 +1,26 @@
+use strict;
+use warnings;
+use Test::More;
+
+use Devel::Peek;
+use Cache::utLRU;
+
+my $cache = Cache::utLRU->new();
+
+# This is combination of 06_keymod.t and 07_keymod2.t using implicit SV mutation via a loop.
+
+my $k;
+while ($k = <DATA>) {
+    chomp $k;
+    Dump($k);
+    $cache->add($k, 1);
+}
+
+my $val = $cache->find("foo");
+is $val, 1, "value found";
+
+done_testing;
+__DATA__
+foo
+bar
+AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA


### PR DESCRIPTION
Add three tests, that show how relatively innocent code may mess up with `keyptr` value that is stored internally by the uthash.

`06_keymod1.t` overwrites the contents of the `keyptr`, causing `find()` to return undef for item present in the hash.
`07_keymod2.t` causes `keyptr` to be reallocated, causing `find()` to read freed memory.
`08_keymod3.t` is a combination of the two above, with a less obvious `SV` modification.