### PR TITLE
Push &PL_sv_undef when failing to find entry

### DIFF
--- a/lru.c
+++ b/lru.c
@@ -59,7 +59,8 @@ SV* cache_find(pTHX_ Cache* cache, SV* key)
     CacheEntry* entry;
     HASH_FIND(hh, cache->data, kptr, klen, entry);
     if (!entry) {
-        return NULL;
+        /* return NULL; */
+        return &PL_sv_undef;
     }
 
     /*


### PR DESCRIPTION
Perl 5 blead now checks for NULL pointers on the stack on debugging builds. The existing find() XS sub pushes a NULL pointer on the stack when it fails to find an entry, when it should probably be pushing &PL_sv_undef.

Enables t/02_basic.t and 03_multi.t to pass once again.

For: https://rt.cpan.org/Ticket/Display.html?id=151315 and https://github.com/Perl/perl5/issues/21876

Per suggestion by Dave Mitchell in
https://rt.cpan.org/Transaction/Display.html?id=2653739: